### PR TITLE
Add configure script for dependency checks

### DIFF
--- a/configure
+++ b/configure
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Configure script to check for required dependencies.
+#
+
+echo "Checking for dependencies..."
+
+# Function to check for a command
+check_command() {
+    printf "Checking for %-20s... " "$1"
+    if command -v "$1" >/dev/null 2>&1; then
+        echo "found"
+    else
+        echo "not found"
+        echo "Error: '$1' is required. Please install it."
+        exit 1
+    fi
+}
+
+# Function to check for a library using pkg-config
+check_library() {
+    printf "Checking for library %-15s... " "$1"
+    if pkg-config --exists "$1"; then
+        echo "found"
+    else
+        echo "not found"
+        echo "Error: '$1' development files are required."
+        echo "On Debian/Ubuntu, try: sudo apt-get install $2"
+        exit 1
+    fi
+}
+
+# Check for essential tools
+check_command gcc
+check_command pkg-config
+check_command xxd
+
+# Check for required libraries
+check_library "libcurl"     "libcurl4-openssl-dev"
+check_library "libcjson"    "libcjson-dev"
+check_library "sdl2"        "libsdl2-dev"
+check_library "SDL2_ttf"    "libsdl2-ttf-dev"
+check_library "SDL2_mixer"  "libsdl2-mixer-dev"
+
+echo
+echo "All dependencies found. You can now run 'make'."
+exit 0


### PR DESCRIPTION
## Summary
- add simple `configure` script to verify tool and library dependencies before building

## Testing
- `./configure` *(fails: "xxd" is required)*
- `make` *(fails: xxd: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b228bb49c48326909c6aa6a3a4be44