### PR TITLE
Document libcjson dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ Track the aircraft nearest to your configured location using ADS-B data from a d
 
 ## Build
 ### Linux
-1. Ensure `libcurl`, `cJSON`, `SDL2`, `SDL2_ttf`, `SDL2_mixer` and `xxd` are installed.
-2. Run `make`.
+1. Ensure `gcc`, `pkg-config`, `xxd`, `libcurl`, `libcjson` (`libcjson-dev` on Debian/Ubuntu), `SDL2`, `SDL2_ttf`, and `SDL2_mixer` are installed.
+2. Run `./configure` to verify dependencies.
+3. Run `make`.
 
 ### Windows
-1. Install the same dependencies using your preferred package manager.
+1. Install the same dependencies (`libcurl`, `libcjson`, `SDL2`, `SDL2_ttf`, `SDL2_mixer`, `xxd`) using your preferred package manager.
 2. Run `make -f Makefile.win`.
 
 ## Controls

--- a/configure
+++ b/configure
@@ -37,7 +37,7 @@ check_command xxd
 
 # Check for required libraries
 check_library "libcurl"     "libcurl4-openssl-dev"
-check_library "libcjson"    "libcjson-dev"
+check_library "libcjson"    "libcjson-dev"    # cJSON library
 check_library "sdl2"        "libsdl2-dev"
 check_library "SDL2_ttf"    "libsdl2-ttf-dev"
 check_library "SDL2_mixer"  "libsdl2-mixer-dev"


### PR DESCRIPTION
## Summary
- mention gcc, pkg-config, xxd, and libcjson in README build instructions
- clarify configure script checks for libcjson

## Testing
- `./configure`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68b2311ca38c832691a5e20aac5a7de5