### PR TITLE
Ensure dump1090 connection uses port 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Track the aircraft nearest to your configured location using ADS-B data from a dump1090 server. The program opens a simple SDL2 window showing flight details and sounds an alert when a plane comes within 5 km.
 
+The application expects the dump1090 server's data feed to be available on port 8080.
+
 ## Build
 ### Linux
 1. Ensure `gcc`, `pkg-config`, `xxd`, `libcurl`, `libcjson` (`libcjson-dev` on Debian/Ubuntu), `SDL2`, `SDL2_ttf`, and `SDL2_mixer` are installed.

--- a/location.conf
+++ b/location.conf
@@ -1,3 +1,4 @@
+# dump1090 server is expected to serve JSON data on port 8080
 server_ip=127.0.0.1
 lat=51.5074
 lon=-0.1278

--- a/main.c
+++ b/main.c
@@ -40,6 +40,7 @@
 #define EARTH_RADIUS_KM 6371.0
 #define REFRESH_INTERVAL_SECONDS 5
 #define PROXIMITY_ALERT_KM 5.0
+#define DUMP1090_PORT 8080
 
 // --- Structs ---
 struct MemoryStruct {
@@ -436,7 +437,8 @@ Mix_Chunk* create_beep(int freq, int duration_ms) {
  */
 void fetch_and_process_data() {
     char dump1090_url[256];
-    snprintf(dump1090_url, sizeof(dump1090_url), "http://%s:8080/dump1090-fa/data/aircraft.json", g_server_ip);
+    snprintf(dump1090_url, sizeof(dump1090_url),
+             "http://%s:%d/dump1090-fa/data/aircraft.json", g_server_ip, DUMP1090_PORT);
 
     CURL *curl_handle = curl_easy_init();
     if (!curl_handle) return;


### PR DESCRIPTION
## Summary
- Introduced `DUMP1090_PORT` constant and construct dump1090 URL using port 8080.
- Documented requirement for port 8080 access in README and `location.conf`.

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68b34dad5d248326ba45616cd2885946